### PR TITLE
[FEATURE] Add time division props to clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ expirationHandler(){
 
 A `Clock` is a utility that tracks time ticks for the current system time.
 
-A `Clock` triggers events on time ticks, including `second`, `minute`, `hour`, `day`,
-and also provides reactful `time` and `date` properties.
+A `Clock` triggers events on time ticks, including `second`, `minute`, `hour`, and `day`.
+A `Clock` also provides reactful `time`, `date`, `second`, `minute`, `hour`, and `day` properties.
 
 ```javascript
 import Clock from "ember-stopwatch/utils/clock";
@@ -136,7 +136,8 @@ myHandler(type){
 
 #### As a Service
 
-A `clock` service can be used that is shared globally in your application.
+A `clock` service automatically creates and starts a single instance of the `Clock` utility and is a proxy for properties and methods of a clock instance.
+A `clock` service also has `@tracked` versions of the clock properties `second`, `minute`, `hour`, and `day` that can be used by the `@computed` macro to react to.
 
 ```javascript
 export default class extends Component {
@@ -146,6 +147,34 @@ export default class extends Component {
 
 ```handlebars
     {{moment-format this.clock.time}}
+```
+
+```javascript
+export default class extends Component {
+    @service clock;
+
+    @computed("clock.minute")
+    get timeByTheMinute() {
+        return new Date().getTime();
+    }
+
+    @computed("clock.hour")
+    get timeByTheHour() {
+        return new Date().getTime();
+    }
+
+    @computed("clock.day")
+    get timeByTheDay() {
+        return new Date().getTime();
+    }
+}
+```
+
+```handlebars
+    Refreshes every second: {{moment-format this.clock.time}}
+    Refreshes every minute: {{moment-format this.timeByTheMinute}}
+    Refreshes every hour: {{moment-format this.timeByTheHour}}
+    Refreshes every day: {{moment-format this.timeByTheDay}}
 ```
 
 ## Compatibility

--- a/addon/services/clock.js
+++ b/addon/services/clock.js
@@ -8,7 +8,14 @@ export default class ClockService extends Service {
     init() {
         super.init(...arguments);
         this.clock.start();
+        this.clock.on('tick', this, this.updateTrackedDivisions);
+        this.updateTrackedDivisions();
     }
+
+    @tracked second;
+    @tracked minute;
+    @tracked hour;
+    @tracked day;
 
     get time() {
         return this.clock.time;
@@ -30,8 +37,33 @@ export default class ClockService extends Service {
         return this.clock.has(name);
     }
 
+    /**
+     * The usage of `@tracked` and the guards in place are intentional
+     * optomizations meant to prevent litening properties from recomputing.
+     * I believe old version of Ember used to optimize for this and prevent
+     * listeners from recomputing if the value was the same. This is useful
+     * for guarding against excessive template helper calls as a clock is
+     * always yielding new time values on every tick.
+     */
+    updateTrackedDivisions() {
+        this.second = this.clock.second;
+
+        if (this.minute !== this.clock.minute) {
+            this.minute = this.clock.minute;
+        }
+
+        if (this.hour !== this.clock.hour) {
+            this.hour = this.clock.hour;
+        }
+
+        if (this.day !== this.clock.day) {
+            this.day = this.clock.day;
+        }
+    }
+
     willDestroy() {
         super.willDestroy(...arguments);
         this.clock.stop(true);
+        this.clock.off('tick', this, this.updateTrackedDivisions);
     }
 }

--- a/addon/utils/clock.js
+++ b/addon/utils/clock.js
@@ -16,10 +16,27 @@ export default class Clock extends Stopwatch {
         return this.date ? this.date.getTime() : undefined;
     }
 
+    get second() {
+        return this.date ? this.date.getSeconds() : undefined;
+    }
+
+    get minute() {
+        return this.date ? this.date.getMinutes() : undefined;
+    }
+
+    get hour() {
+        return this.date ? this.date.getHours() : undefined;
+    }
+
+    get day() {
+        return this.date ? this.date.getDate() : undefined;
+    }
+
     start() {
         if (!this.date) {
             // start on a discrete tick
             this.date = new Date();
+
             setTimeout(() => {
                 super.start();
             }, this.tickMillis - (Date.now() % this.tickMillis));
@@ -29,13 +46,13 @@ export default class Clock extends Stopwatch {
     _tickHandler() {
         const prevDate = this.date;
         this.date = new Date();
-        this.trigger('second', this);
 
+        this.trigger('second', this);
         if (prevDate.getMinutes() !== this.date.getMinutes()) {
             this.trigger('minute', this);
             if (prevDate.getHours() !== this.date.getHours()) {
                 this.trigger('hour', this);
-                if (prevDate.getDay() !== this.date.getDay()) {
+                if (prevDate.getDate() !== this.date.getDate()) {
                     this.trigger('day', this);
                 }
             }

--- a/tests/dummy/app/components/clock-demo.js
+++ b/tests/dummy/app/components/clock-demo.js
@@ -1,6 +1,22 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 
-export default class StopwatchDemoComponent extends Component {
+export default class ClockDemoComponent extends Component {
     @service clock;
+
+    @computed('clock.minute')
+    get timeByTheMinute() {
+        return new Date().getTime();
+    }
+
+    @computed('clock.hour')
+    get timeByTheHour() {
+        return new Date().getTime();
+    }
+
+    @computed('clock.day')
+    get timeByTheDay() {
+        return new Date().getTime();
+    }
 }

--- a/tests/dummy/app/components/timer-demo.js
+++ b/tests/dummy/app/components/timer-demo.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import Timer from 'ember-stopwatch/utils/timer';
 import { tracked } from 'tracked-built-ins';
 
-export default class StopwatchDemoComponent extends Component {
+export default class TimerDemoComponent extends Component {
     @tracked secondTimer = new Timer(1000);
     @tracked tenSecondTimer = new Timer(10000);
     @tracked minuteTimer = new Timer(60000);

--- a/tests/dummy/app/templates/components/clock-demo.hbs
+++ b/tests/dummy/app/templates/components/clock-demo.hbs
@@ -2,8 +2,49 @@
     <div
         class="grid grid-flow-col grid-rows-1 gap-4 items-start"
     >
-        <div class="bg-white rounded p-2 font-mono">
-            {{moment-format this.clock.time}}
+        <div class="bg-white rounded p-2">
+            <div class="font-bold text-2xl underline">
+                Second Clock
+            </div>
+            <div class="font-thin">
+                Refreshes every second
+            </div>
+            <div class="font-mono" data-test-second-clock>
+                {{moment-format this.clock.time}}
+            </div>
+        </div>
+        <div class="bg-white rounded p-2">
+            <div class="font-bold text-2xl underline">
+                Minute Clock
+            </div>
+            <div class="font-thin">
+                Refreshes every minute
+            </div>
+            <div class="font-mono" data-test-minute-clock>
+                {{moment-format this.timeByTheMinute}}
+            </div>
+        </div>
+        <div class="bg-white rounded p-2">
+            <div class="font-bold text-2xl underline">
+                Hour Clock
+            </div>
+            <div class="font-thin">
+                Refreshes every hour
+            </div>
+            <div class="font-mono" data-test-hour-clock>
+                {{moment-format this.timeByTheHour}}
+            </div>
+        </div>
+        <div class="bg-white rounded p-2">
+            <div class="font-bold text-2xl underline">
+                Day Clock
+            </div>
+            <div class="font-thin">
+                Refreshes every day
+            </div>
+            <div class="font-mono" data-test-day-clock>
+                {{moment-format this.timeByTheDay}}
+            </div>
         </div>
     </div>
 </div>

--- a/tests/integration/components/clock-demo-test.js
+++ b/tests/integration/components/clock-demo-test.js
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { find } from '@ember/test-helpers';
+
+import fakeTimers from '@sinonjs/fake-timers';
+
+module('Integration | Component | ClockDemo', function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+        this.nativeTimer = fakeTimers.install();
+    });
+
+    hooks.afterEach(function () {
+        this.nativeTimer.uninstall();
+    });
+
+    test('should render new values for each clock type, but only when respective time divisions change', async function (assert) {
+        await render(hbs`<ClockDemo/>`);
+
+        const originalSecondClock = find('[data-test-second-clock]').textContent;
+        const originalMinuteClock = find('[data-test-minute-clock]').textContent;
+        const originalHourClock = find('[data-test-hour-clock]').textContent;
+        const originalDayClock = find('[data-test-day-clock]').textContent;
+
+        this.nativeTimer.tick(1000); // Move forward a second
+        await this.nativeTimer.nextAsync();
+
+        assert.notEqual(find('[data-test-second-clock]').textContent, originalSecondClock);
+        assert.equal(find('[data-test-minute-clock]').textContent, originalMinuteClock);
+        assert.equal(find('[data-test-hour-clock]').textContent, originalHourClock);
+        assert.equal(find('[data-test-day-clock]').textContent, originalDayClock);
+
+        this.nativeTimer.tick(1000 * 60); // Move forward a minute
+        await this.nativeTimer.nextAsync();
+
+        assert.notEqual(find('[data-test-second-clock]').textContent, originalSecondClock);
+        assert.notEqual(find('[data-test-minute-clock]').textContent, originalMinuteClock);
+        assert.equal(find('[data-test-hour-clock]').textContent, originalHourClock);
+        assert.equal(find('[data-test-day-clock]').textContent, originalDayClock);
+
+        this.nativeTimer.tick(1000 * 60 * 60); // Move forward an hour
+        await this.nativeTimer.nextAsync();
+
+        assert.notEqual(find('[data-test-second-clock]').textContent, originalSecondClock);
+        assert.notEqual(find('[data-test-minute-clock]').textContent, originalMinuteClock);
+        assert.notEqual(find('[data-test-hour-clock]').textContent, originalHourClock);
+        assert.equal(find('[data-test-day-clock]').textContent, originalDayClock);
+
+        this.nativeTimer.tick(1000 * 60 * 60 * 24); // Move forward a day
+        await this.nativeTimer.nextAsync();
+        assert.notEqual(find('[data-test-second-clock]').textContent, originalSecondClock);
+        assert.notEqual(find('[data-test-minute-clock]').textContent, originalMinuteClock);
+        assert.notEqual(find('[data-test-hour-clock]').textContent, originalHourClock);
+        assert.notEqual(find('[data-test-day-clock]').textContent, originalDayClock);
+    });
+});

--- a/tests/unit/services/clock-test.js
+++ b/tests/unit/services/clock-test.js
@@ -3,11 +3,15 @@ import { setupTest } from 'ember-qunit';
 import fakeTimers from '@sinonjs/fake-timers';
 import { assertClockListeners } from '../shared';
 
+// force starting on a second boundary
+// 2020-04-02T09:13:14.000Z
+const SYSTEM_START = 1585818794000;
+
 module('Unit | Service | clock', function (hooks) {
     setupTest(hooks);
 
     hooks.beforeEach(function () {
-        this.nativeTimer = fakeTimers.install({ now: 1585818794000 });
+        this.nativeTimer = fakeTimers.install({ now: SYSTEM_START });
     });
 
     hooks.afterEach(function () {
@@ -28,5 +32,28 @@ module('Unit | Service | clock', function (hooks) {
     test('service listeners', function (assert) {
         const clock = this.owner.lookup('service:clock');
         assertClockListeners(assert, clock, this.nativeTimer);
+    });
+
+    test('clock tracked props are set on init', function (assert) {
+        const clock = this.owner.lookup('service:clock');
+        const systemStartDate = new Date(SYSTEM_START);
+
+        assert.equal(
+            clock.second,
+            systemStartDate.getSeconds(),
+            `second is set correctly: ${systemStartDate.getSeconds()}`
+        );
+        assert.equal(
+            clock.minute,
+            systemStartDate.getMinutes(),
+            `minute is set correctly: ${systemStartDate.getMinutes()}`
+        );
+        assert.equal(clock.hour, systemStartDate.getHours(), `hour is set correctly: ${systemStartDate.getHours()}`);
+        assert.equal(clock.day, systemStartDate.getDate(), `day is set correctly: ${systemStartDate.getDate()}`);
+
+        assert.equal(clock.clock.second, clock.second, 'service second matches util second');
+        assert.equal(clock.clock.minute, clock.minute, 'service minute matches util minute');
+        assert.equal(clock.clock.hour, clock.hour, 'service hour matches util hour');
+        assert.equal(clock.clock.day, clock.day, 'service day matches util day');
     });
 });


### PR DESCRIPTION
* This addresses #75 and includes new time divisions props on the Clock util, and adds time division props to clock service as `@tracked` properties instead of just getter passthroughs so that the `@computed` macro can react to them