### PR TITLE
chore: update several addon dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -977,24 +977,6 @@
         }
       }
     },
-    "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
-      "integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
-          "dev": true
-        }
-      }
-    },
     "@babel/plugin-proposal-numeric-separator": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
@@ -1041,50 +1023,6 @@
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
           "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-        }
-      }
-    },
-    "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
-      "integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
-          "dev": true
-        },
-        "@babel/helper-skip-transparent-expression-wrappers": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
-          "integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -4376,6 +4314,21 @@
         "ember-destroyable-polyfill": "^2.0.3"
       },
       "dependencies": {
+        "async-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.3",
+            "istextorbinary": "^2.5.1",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "rsvp": "^4.8.5",
+            "username-sync": "^1.0.2"
+          }
+        },
         "broccoli-funnel": {
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
@@ -4391,6 +4344,42 @@
             "walk-sync": "^2.0.2"
           }
         },
+        "broccoli-persistent-filter": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
+          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^2.0.0",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^4.0.3",
+            "fs-tree-diff": "^2.0.0",
+            "hash-for-dep": "^1.5.0",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.0.1",
+            "sync-disk-cache": "^2.0.0"
+          },
+          "dependencies": {
+            "promise-map-series": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+              "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+              "dev": true,
+              "requires": {
+                "rsvp": "^3.0.14"
+              }
+            },
+            "rsvp": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
+            }
+          }
+        },
         "broccoli-plugin": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
@@ -4404,6 +4393,65 @@
             "quick-temp": "^0.1.8",
             "rimraf": "^3.0.2",
             "symlink-or-copy": "^1.3.1"
+          }
+        },
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "ember-cli-babel-plugin-helpers": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz",
+          "integrity": "sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==",
+          "dev": true
+        },
+        "ember-cli-htmlbars": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz",
+          "integrity": "sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==",
+          "dev": true,
+          "requires": {
+            "@ember/edition-utils": "^1.2.0",
+            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+            "broccoli-debug": "^0.6.5",
+            "broccoli-persistent-filter": "^3.1.2",
+            "broccoli-plugin": "^4.0.3",
+            "common-tags": "^1.8.0",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "ember-cli-version-checker": "^5.1.2",
+            "fs-tree-diff": "^2.0.1",
+            "hash-for-dep": "^1.5.1",
+            "heimdalljs-logger": "^0.1.10",
+            "json-stable-stringify": "^1.0.1",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1",
+            "strip-bom": "^4.0.0",
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
           }
         },
         "fs-extra": {
@@ -4443,6 +4491,17 @@
             "symlink-or-copy": "^1.1.8"
           }
         },
+        "istextorbinary": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.2.0",
+            "textextensions": "^2.5.0"
+          }
+        },
         "matcher-collection": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -4458,6 +4517,48 @@
           "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
           "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "sync-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.6",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "username-sync": "^1.0.2"
+          }
         },
         "walk-sync": {
           "version": "2.2.0",
@@ -7132,6 +7233,11 @@
         "babel-template": "^6.24.1"
       }
     },
+    "babel-import-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-0.2.0.tgz",
+      "integrity": "sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag=="
+    },
     "babel-loader": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
@@ -7178,6 +7284,25 @@
         "@ember-data/rfc395-data": "^0.0.4"
       }
     },
+    "babel-plugin-ember-modules-api-polyfill": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.5.0.tgz",
+      "integrity": "sha512-pJajN/DkQUnStw0Az8c6khVcMQHgzqWr61lLNtVeu0g61LRW0k9jyK7vaedrHDWGe/Qe8sxG5wpiyW9NsMqFzA==",
+      "requires": {
+        "ember-rfc176-data": "^0.3.17"
+      }
+    },
+    "babel-plugin-ember-template-compilation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-1.0.0.tgz",
+      "integrity": "sha512-SvDQ+DbimZEq7XZztxiCKPNO3/HEwAOKBdJ9r4qtMpgmSuuhzO1elkixJTrnwnkLv1titAYAXNqLVD1fkE4Vgg==",
+      "requires": {
+        "babel-import-util": "^0.2.0",
+        "line-column": "^1.0.2",
+        "magic-string": "^0.25.7",
+        "string.prototype.matchall": "^4.0.5"
+      }
+    },
     "babel-plugin-filter-imports": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-filter-imports/-/babel-plugin-filter-imports-4.0.0.tgz",
@@ -7189,26 +7314,15 @@
       }
     },
     "babel-plugin-htmlbars-inline-precompile": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-5.0.0.tgz",
-      "integrity": "sha512-ZPIV7zVwVcwRyTWCp29HSwIPcvqX7PoslpKlNu53AzAx5X4QBwuMb9fFsUYY3JcriNZb5xWFOM4AE95XW0UYeA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-5.3.1.tgz",
+      "integrity": "sha512-QWjjFgSKtSRIcsBhJmEwS2laIdrA6na8HAlc/pEAhjHgQsah/gMiBFRZvbQTy//hWxR4BMwV7/Mya7q5H8uHeA==",
       "requires": {
-        "babel-plugin-ember-modules-api-polyfill": "^3.4.0"
-      },
-      "dependencies": {
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.5.0.tgz",
-          "integrity": "sha512-pJajN/DkQUnStw0Az8c6khVcMQHgzqWr61lLNtVeu0g61LRW0k9jyK7vaedrHDWGe/Qe8sxG5wpiyW9NsMqFzA==",
-          "requires": {
-            "ember-rfc176-data": "^0.3.17"
-          }
-        },
-        "ember-rfc176-data": {
-          "version": "0.3.17",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz",
-          "integrity": "sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw=="
-        }
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "line-column": "^1.0.2",
+        "magic-string": "^0.25.7",
+        "parse-static-imports": "^1.1.0",
+        "string.prototype.matchall": "^4.0.5"
       }
     },
     "babel-plugin-istanbul": {
@@ -8723,7 +8837,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.5.tgz",
       "integrity": "sha512-bQAtwjSrF4Nu0CK0JOy5OZqw9t5U0zzv2555EA/cF8/a8SLDTIetk9UgrtMVw7qKLKdSpOZ2liZNeZZDaKgayw==",
-      "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
         "heimdalljs-logger": "^0.1.10",
@@ -8734,7 +8847,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -9707,6 +9819,15 @@
         "json-stable-stringify": "^1.0.1"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -10185,7 +10306,8 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -13018,17 +13140,16 @@
       "dev": true
     },
     "ember-cli-htmlbars": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz",
-      "integrity": "sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.0.0.tgz",
+      "integrity": "sha512-7h9Lb1kfvLecMUOX8wCbwjzCsgXdNDs8qpOsDuKV6YaGS9jDZHu4P5xTYLX78YepEUnwOw1atCYWzBUsJHWrzA==",
       "requires": {
         "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "babel-plugin-ember-template-compilation": "^1.0.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.3.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-persistent-filter": "^3.1.2",
         "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
         "ember-cli-version-checker": "^5.1.2",
         "fs-tree-diff": "^2.0.1",
         "hash-for-dep": "^1.5.1",
@@ -13054,16 +13175,6 @@
             "username-sync": "^1.0.2"
           }
         },
-        "broccoli-output-wrapper": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.5.tgz",
-          "integrity": "sha512-bQAtwjSrF4Nu0CK0JOy5OZqw9t5U0zzv2555EA/cF8/a8SLDTIetk9UgrtMVw7qKLKdSpOZ2liZNeZZDaKgayw==",
-          "requires": {
-            "fs-extra": "^8.1.0",
-            "heimdalljs-logger": "^0.1.10",
-            "symlink-or-copy": "^1.2.0"
-          }
-        },
         "broccoli-persistent-filter": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
@@ -13083,13 +13194,13 @@
           }
         },
         "broccoli-plugin": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.5.tgz",
-          "integrity": "sha512-WA8FQP2EQCBOd1Z6RhXlyTyt/F+sJEwWGTCUrIIBDxHhSURibPW/n0NfwgLdEZSD8/3Ec4B9L3PUqaWxVuVC2A==",
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.1.0",
+            "fs-merger": "^3.2.1",
             "promise-map-series": "^0.3.0",
             "quick-temp": "^0.1.8",
             "rimraf": "^3.0.2",
@@ -13119,11 +13230,6 @@
             }
           }
         },
-        "ember-cli-babel-plugin-helpers": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz",
-          "integrity": "sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw=="
-        },
         "ember-cli-version-checker": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
@@ -13132,16 +13238,6 @@
             "resolve-package-path": "^3.1.0",
             "semver": "^7.3.4",
             "silent-error": "^1.1.1"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
           }
         },
         "fs-tree-diff": {
@@ -13154,14 +13250,6 @@
             "object-assign": "^4.1.0",
             "path-posix": "^1.0.0",
             "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "is-core-module": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-          "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-          "requires": {
-            "has": "^1.0.3"
           }
         },
         "istextorbinary": {
@@ -13202,9 +13290,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -13949,29 +14037,25 @@
       }
     },
     "ember-modifier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-2.1.2.tgz",
-      "integrity": "sha512-3Lsu1fV1sIGa66HOW07RZc6EHISwKt5VA5AUnFss2HX6OTfpxTJ2qvPctt2Yt0XPQXJ4G6BQasr/F35CX7UGJA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.0.0.tgz",
+      "integrity": "sha512-ccXfMnjWhjEUCB5taeIPQmf0h1zPUIMbmsCV7W+JZ2BioPUZTLhE1WuHspmV0iEOiX3Fwx8jMOx6b74sFcKJ0g==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.22.1",
+        "ember-cli-babel": "^7.26.6",
         "ember-cli-normalize-entity-name": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^3.1.3",
-        "ember-compatibility-helpers": "^1.2.4",
-        "ember-destroyable-polyfill": "^2.0.2",
-        "ember-modifier-manager-polyfill": "^1.2.0"
+        "ember-cli-typescript": "^4.2.1",
+        "ember-compatibility-helpers": "^1.2.5"
       },
       "dependencies": {
-        "@babel/plugin-transform-typescript": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
-          "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
+        "ansi-to-html": {
+          "version": "0.6.15",
+          "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.15.tgz",
+          "integrity": "sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==",
           "dev": true,
           "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.8.3",
-            "@babel/helper-plugin-utils": "^7.8.3",
-            "@babel/plugin-syntax-typescript": "^7.8.3"
+            "entities": "^2.0.0"
           }
         },
         "babel-plugin-debug-macros": {
@@ -13992,25 +14076,21 @@
           }
         },
         "ember-cli-typescript": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
-          "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+          "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
           "dev": true,
           "requires": {
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-            "@babel/plugin-transform-typescript": "~7.8.0",
-            "ansi-to-html": "^0.6.6",
+            "ansi-to-html": "^0.6.15",
             "broccoli-stew": "^3.0.0",
             "debug": "^4.0.0",
-            "ember-cli-babel-plugin-helpers": "^1.0.0",
-            "execa": "^3.0.0",
-            "fs-extra": "^8.0.0",
+            "execa": "^4.0.0",
+            "fs-extra": "^9.0.1",
             "resolve": "^1.5.0",
             "rsvp": "^4.8.1",
-            "semver": "^6.3.0",
+            "semver": "^7.3.2",
             "stagehand": "^1.0.0",
-            "walk-sync": "^2.0.0"
+            "walk-sync": "^2.2.0"
           }
         },
         "ember-cli-version-checker": {
@@ -14022,23 +14102,12 @@
             "resolve-package-path": "^3.1.0",
             "semver": "^7.3.4",
             "silent-error": "^1.1.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "7.3.5",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-              "dev": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            }
           }
         },
         "ember-compatibility-helpers": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz",
-          "integrity": "sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz",
+          "integrity": "sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==",
           "dev": true,
           "requires": {
             "babel-plugin-debug-macros": "^0.2.0",
@@ -14047,46 +14116,24 @@
             "semver": "^5.4.1"
           },
           "dependencies": {
-            "fs-extra": {
-              "version": "9.1.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-              "dev": true,
-              "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            },
-            "jsonfile": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-              "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-              }
-            },
             "semver": {
               "version": "5.7.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true
-            },
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
             }
           }
         },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+          "dev": true
+        },
         "execa": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -14096,29 +14143,30 @@
             "merge-stream": "^2.0.0",
             "npm-run-path": "^4.0.0",
             "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
             "signal-exit": "^3.0.2",
             "strip-final-newline": "^2.0.0"
           }
         },
         "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
+            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
-        "is-core-module": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-          "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
-            "has": "^1.0.3"
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
           }
         },
         "matcher-collection": {
@@ -14163,9 +14211,18 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         },
         "walk-sync": {
@@ -14519,6 +14576,11 @@
           }
         }
       }
+    },
+    "ember-rfc176-data": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz",
+      "integrity": "sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw=="
     },
     "ember-router-generator": {
       "version": "2.0.0",
@@ -15455,7 +15517,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -15873,18 +15934,18 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-qunit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
-      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.0.0.tgz",
+      "integrity": "sha512-yPh02tbQoZK43voIfJFO9CUN5Q6j8ebfrnxEqPr7I4UiYln4RWKDQ4ajaHgV3gJKSAUZwymJ0DsB/YH6btRxIQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
@@ -16838,16 +16899,15 @@
       }
     },
     "fs-merger": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.1.0.tgz",
-      "integrity": "sha512-RZ9JtqugaE8Rkt7idO5NSwcxEGSDZpLmVFjtVQUm3f+bWun7JAU6fKyU6ZJUeUnKdJwGx8uaro+K4QQfOR7vpA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.2.1.tgz",
+      "integrity": "sha512-AN6sX12liy0JE7C2evclwoo0aCG3PFulLjrTLsJpWh/2mM+DinhpSGqYLbHBBbIW1PLRNcFhJG8Axtz8mQW3ug==",
       "requires": {
         "broccoli-node-api": "^1.7.0",
         "broccoli-node-info": "^2.1.0",
         "fs-extra": "^8.0.1",
         "fs-tree-diff": "^2.0.1",
-        "rimraf": "^2.6.3",
-        "walk-sync": "^2.0.2"
+        "walk-sync": "^2.2.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -16879,14 +16939,6 @@
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
           }
         },
         "walk-sync": {
@@ -17040,6 +17092,16 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -17059,6 +17121,15 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "get-value": {
@@ -17438,6 +17509,11 @@
         }
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -17461,6 +17537,21 @@
       "dev": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
+      }
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
       }
     },
     "has-unicode": {
@@ -18154,6 +18245,16 @@
         }
       }
     },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
     "into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -18205,6 +18306,14 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -18212,6 +18321,15 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -18223,8 +18341,7 @@
     "is-callable": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-      "dev": true
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-color-stop": {
       "version": "1.1.0",
@@ -18244,7 +18361,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
       "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -18272,8 +18388,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -18351,6 +18466,11 @@
       "integrity": "sha512-6xKmRRcP2YdmMBZMVS3uiJRPQgcMYolkD6hFw2Y4KjqyIyaJlCGxUt56tuu0iIV8q9r8kMEo0Gjd/GFwKrgjbw==",
       "dev": true
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -18369,6 +18489,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-obj": {
@@ -18431,17 +18559,29 @@
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+    },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true
     },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -18475,6 +18615,14 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -18800,6 +18948,30 @@
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
       "integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
       "dev": true
+    },
+    "line-column": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+      "integrity": "sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=",
+      "requires": {
+        "isarray": "^1.0.0",
+        "isobject": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        }
+      }
     },
     "line-stream": {
       "version": "0.0.0",
@@ -19191,6 +19363,14 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -20689,6 +20869,11 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parse-static-imports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-static-imports/-/parse-static-imports-1.1.0.tgz",
+      "integrity": "sha512-HlxrZcISCblEV0lzXmAHheH/8qEkKgmqkdxyHTPbSqsTUV8GzqmN1L+SSti+VbNPfbBO3bYLPHDiUs2avbAdbA=="
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -21890,6 +22075,15 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -22529,6 +22723,23 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+        }
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -22907,6 +23118,11 @@
       "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
       "dev": true
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "sourcemap-validator": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.1.1.tgz",
@@ -23202,6 +23418,85 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "string.prototype.matchall": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.3.1",
+        "side-channel": "^1.0.4"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
+      }
+    },
     "string.prototype.padend": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
@@ -23210,6 +23505,15 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimleft": {
@@ -23230,6 +23534,15 @@
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -23425,9 +23738,9 @@
       }
     },
     "tailwindcss": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.16.tgz",
-      "integrity": "sha512-EireCtpQyyJ4Xz8NYzHafBoy4baCOO96flM0+HgtsFcIQ9KFy/YBK3GEtlnD+rXen0e4xm8t3WiUcKBJmN6yjg==",
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.17.tgz",
+      "integrity": "sha512-WgRpn+Pxn7eWqlruxnxEbL9ByVRWi3iC10z4b6dW0zSdnkPVC4hPMSWLQkkW8GCyBIv/vbJ0bxIi9dVrl4CfoA==",
       "dev": true,
       "requires": {
         "arg": "^5.0.1",
@@ -24535,6 +24848,24 @@
         }
       }
     },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
+      }
+    },
     "underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
@@ -25294,6 +25625,18 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "which-pm-runs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1"
+    "ember-cli-htmlbars": "^6.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.2.1",
@@ -62,7 +62,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-modifier": "^2.1.2",
+    "ember-modifier": "^3.0.0",
     "ember-page-title": "^6.2.2",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
@@ -75,8 +75,8 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.7",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.4.1",
-    "eslint-plugin-qunit": "^6.2.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-qunit": "^7.0.0",
     "husky": "4.3.8",
     "loader.js": "^4.7.0",
     "micromatch": "^4.0.4",
@@ -87,7 +87,7 @@
     "qunit": "^2.17.2",
     "qunit-dom": "^2.0.0",
     "rimraf": "^3.0.2",
-    "tailwindcss": "^2.2.16",
+    "tailwindcss": "^2.2.17",
     "tracked-built-ins": "^1.1.1"
   },
   "engines": {

--- a/tests/integration/components/clock-demo-test.js
+++ b/tests/integration/components/clock-demo-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | ClockDemo', function (hooks) {
         this.nativeTimer.uninstall();
     });
 
-    const assertEqualTrim = (assert, s1, s2, msg) => assert.equal((s1 || '').trim(), (s2 || '').trim(), msg);
+    const assertEqualTrim = (assert, s1, s2, msg) => assert.strictEqual((s1 || '').trim(), (s2 || '').trim(), msg);
     // NOTE: On Ember 3.12 the notEqual helper adds a NOT in the result value... hence why I'm using notOk
     const assertNotEqualTrim = (assert, s1, s2, msg) => assert.notOk((s1 || '').trim() === (s2 || '').trim(), msg);
 

--- a/tests/integration/modifiers/clock-tick-test.js
+++ b/tests/integration/modifiers/clock-tick-test.js
@@ -24,7 +24,10 @@ module('Integration | Modifier | clock-tick', function (hooks) {
     test('it asserts when not enough arguments are provided', async function (assert) {
         assert.expect(1);
         setupOnerror((err) =>
-            assert.equal(err.message, `Assertion Failed: You must provide at least 2 arguments for {{clock-tick}}`)
+            assert.strictEqual(
+                err.message,
+                `Assertion Failed: You must provide at least 2 arguments for {{clock-tick}}`
+            )
         );
         await render(hbs`<div {{clock-tick}}></div>`);
     });
@@ -32,7 +35,7 @@ module('Integration | Modifier | clock-tick', function (hooks) {
     test('it asserts when a non-string tickType is provided', async function (assert) {
         assert.expect(1);
         setupOnerror((err) =>
-            assert.equal(
+            assert.strictEqual(
                 err.message,
                 `Assertion Failed: You must provide a string as the first positional argument for {{clock-tick}}`
             )
@@ -46,7 +49,7 @@ module('Integration | Modifier | clock-tick', function (hooks) {
     test('it asserts when an invalid tickType is provided', async function (assert) {
         assert.expect(1);
         setupOnerror((err) =>
-            assert.equal(err.message, `Assertion Failed: You provided an invalid duration argument {{foo}}`)
+            assert.strictEqual(err.message, `Assertion Failed: You provided an invalid duration argument {{foo}}`)
         );
         this.set('foo', () => {
             assert.notOk(true, 'Should not have made it here');
@@ -59,9 +62,9 @@ module('Integration | Modifier | clock-tick', function (hooks) {
         this.set('foo', (time) => {
             this.set('time', time);
         });
-        await render(hbs`<div {{clock-tick "second" this.foo}}>{{time}}</div>`);
-        assert.equal(this.element.textContent.trim(), '');
+        await render(hbs`<div {{clock-tick "second" this.foo}}>{{this.time}}</div>`);
+        assert.strictEqual(this.element.textContent.trim(), '');
         this.nativeTimer.tick(SECOND_RESOLUTION);
-        assert.equal(this.element.textContent.trim(), `${1585818794000 + SECOND_RESOLUTION}`);
+        assert.strictEqual(this.element.textContent.trim(), `${1585818794000 + SECOND_RESOLUTION}`);
     });
 });

--- a/tests/integration/modifiers/stopwatch-tick-test.js
+++ b/tests/integration/modifiers/stopwatch-tick-test.js
@@ -24,7 +24,10 @@ module('Integration | Modifier | stopwatch-tick', function (hooks) {
     test('it asserts when not enough arguments are provided', async function (assert) {
         assert.expect(1);
         setupOnerror((err) =>
-            assert.equal(err.message, `Assertion Failed: You must provide at least 2 arguments for {{stopwatch-tick}}`)
+            assert.strictEqual(
+                err.message,
+                `Assertion Failed: You must provide at least 2 arguments for {{stopwatch-tick}}`
+            )
         );
         await render(hbs`<div {{stopwatch-tick}}></div>`);
     });
@@ -32,7 +35,7 @@ module('Integration | Modifier | stopwatch-tick', function (hooks) {
     test('it asserts when an invalid duration is provided', async function (assert) {
         assert.expect(2);
         setupOnerror((err) =>
-            assert.equal(
+            assert.strictEqual(
                 err.message,
                 `Assertion Failed: You must provide a positive number as the first positional argument for {{stopwatch-tick}}`
             )
@@ -57,16 +60,18 @@ module('Integration | Modifier | stopwatch-tick', function (hooks) {
             });
         };
         reset();
-        await render(hbs`<div {{stopwatch-tick 1000 this.foo}}>{{status}},{{duration}},{{ticks}}</div>`);
-        assert.equal(this.element.textContent.trim(), 'running,0,0');
+        await render(hbs`<div {{stopwatch-tick 1000 this.foo}}>{{this.status}},{{this.duration}},{{this.ticks}}</div>`);
+        assert.strictEqual(this.element.textContent.trim(), 'running,0,0');
         this.nativeTimer.tick(SECOND_RESOLUTION);
-        assert.equal(this.element.textContent.trim(), `done,${SECOND_RESOLUTION},1`);
+        assert.strictEqual(this.element.textContent.trim(), `done,${SECOND_RESOLUTION},1`);
 
         reset();
-        await render(hbs`<div {{stopwatch-tick 1000 this.foo ticks=5}}>{{status}},{{duration}},{{ticks}}</div>`);
-        assert.equal(this.element.textContent.trim(), 'running,0,0');
+        await render(
+            hbs`<div {{stopwatch-tick 1000 this.foo ticks=5}}>{{this.status}},{{this.duration}},{{this.ticks}}</div>`
+        );
+        assert.strictEqual(this.element.textContent.trim(), 'running,0,0');
         this.nativeTimer.tick(SECOND_RESOLUTION * 10);
-        assert.equal(this.element.textContent.trim(), `done,${SECOND_RESOLUTION * 5},5`);
+        assert.strictEqual(this.element.textContent.trim(), `done,${SECOND_RESOLUTION * 5},5`);
     });
 
     test('it renders notify-after alias', async function (assert) {
@@ -75,9 +80,9 @@ module('Integration | Modifier | stopwatch-tick', function (hooks) {
         this.set('foo', (status) => {
             this.set('status', status);
         });
-        await render(hbs`<div {{call-after 500 (fn this.foo "bar")}}>{{status}}</div>`);
-        assert.equal(this.element.textContent.trim(), 'foo');
+        await render(hbs`<div {{call-after 500 (fn this.foo "bar")}}>{{this.status}}</div>`);
+        assert.strictEqual(this.element.textContent.trim(), 'foo');
         this.nativeTimer.tick(SECOND_RESOLUTION);
-        assert.equal(this.element.textContent.trim(), `bar`);
+        assert.strictEqual(this.element.textContent.trim(), `bar`);
     });
 });

--- a/tests/unit/services/clock-test.js
+++ b/tests/unit/services/clock-test.js
@@ -28,7 +28,7 @@ module('Unit | Service | clock', function (hooks) {
         assert.expect(2);
         const service = this.owner.lookup('service:clock');
         assert.ok(service.time, `clock should be running`);
-        assert.equal(service.date.getTime(), service.time, `time and date are equal`);
+        assert.strictEqual(service.date.getTime(), service.time, `time and date are equal`);
     });
 
     test('service listeners', function (assert) {
@@ -42,22 +42,26 @@ module('Unit | Service | clock', function (hooks) {
         const clock = this.owner.lookup('service:clock');
         const systemStartDate = new Date(SYSTEM_START);
 
-        assert.equal(
+        assert.strictEqual(
             clock.second,
             systemStartDate.getSeconds(),
             `second is set correctly: ${systemStartDate.getSeconds()}`
         );
-        assert.equal(
+        assert.strictEqual(
             clock.minute,
             systemStartDate.getMinutes(),
             `minute is set correctly: ${systemStartDate.getMinutes()}`
         );
-        assert.equal(clock.hour, systemStartDate.getHours(), `hour is set correctly: ${systemStartDate.getHours()}`);
-        assert.equal(clock.day, systemStartDate.getDate(), `day is set correctly: ${systemStartDate.getDate()}`);
+        assert.strictEqual(
+            clock.hour,
+            systemStartDate.getHours(),
+            `hour is set correctly: ${systemStartDate.getHours()}`
+        );
+        assert.strictEqual(clock.day, systemStartDate.getDate(), `day is set correctly: ${systemStartDate.getDate()}`);
 
-        assert.equal(clock.clock.second, clock.second, 'service second matches util second');
-        assert.equal(clock.clock.minute, clock.minute, 'service minute matches util minute');
-        assert.equal(clock.clock.hour, clock.hour, 'service hour matches util hour');
-        assert.equal(clock.clock.day, clock.day, 'service day matches util day');
+        assert.strictEqual(clock.clock.second, clock.second, 'service second matches util second');
+        assert.strictEqual(clock.clock.minute, clock.minute, 'service minute matches util minute');
+        assert.strictEqual(clock.clock.hour, clock.hour, 'service hour matches util hour');
+        assert.strictEqual(clock.clock.day, clock.day, 'service day matches util day');
     });
 });

--- a/tests/unit/services/stopwatch-test.js
+++ b/tests/unit/services/stopwatch-test.js
@@ -26,33 +26,33 @@ module('Unit | Service | stopwatch', function (hooks) {
         const service = this.owner.lookup('service:stopwatch');
         service.start();
         assert.ok(service.isRunning, `stopwatch should be running`);
-        assert.equal(service.elapsedMillis, 0, `stopwatch tick has not been triggered yet`);
+        assert.strictEqual(service.elapsedMillis, 0, `stopwatch tick has not been triggered yet`);
 
         this.nativeTimer.tick(DEFAULT_TICK_MILLIS);
-        assert.equal(service.elapsedMillis, DEFAULT_TICK_MILLIS, `stopwatch has ticked`);
-        assert.equal(service.systemElapsedMillis, DEFAULT_TICK_MILLIS, `system should be the same`);
-        assert.equal(service.variance, 0, `should have no variance`);
-        assert.equal(service.numTicks, 1, `one tick`);
+        assert.strictEqual(service.elapsedMillis, DEFAULT_TICK_MILLIS, `stopwatch has ticked`);
+        assert.strictEqual(service.systemElapsedMillis, DEFAULT_TICK_MILLIS, `system should be the same`);
+        assert.strictEqual(service.variance, 0, `should have no variance`);
+        assert.strictEqual(service.numTicks, 1, `one tick`);
 
         service.reset(true);
         this.nativeTimer.tick(DEFAULT_TICK_MILLIS);
-        assert.equal(service.numTicks, 0, `0 ticks`);
+        assert.strictEqual(service.numTicks, 0, `0 ticks`);
 
         service.start();
         this.nativeTimer.tick(DEFAULT_TICK_MILLIS * 2 - 1);
-        assert.equal(service.numTicks, 1, `1 tick`);
+        assert.strictEqual(service.numTicks, 1, `1 tick`);
         // async reset
         service.reset();
-        assert.equal(service.numTicks, 1, `still 1 tick`);
+        assert.strictEqual(service.numTicks, 1, `still 1 tick`);
         this.nativeTimer.tick(1);
-        assert.equal(service.numTicks, 0, `back to 0 ticks`);
+        assert.strictEqual(service.numTicks, 0, `back to 0 ticks`);
 
         service.start();
         this.nativeTimer.tick(DEFAULT_TICK_MILLIS - 1);
         // async stop
         service.stop();
         this.nativeTimer.tick(DEFAULT_TICK_MILLIS * 10 + 1);
-        assert.equal(service.numTicks, 1, `still has 1 tick`);
+        assert.strictEqual(service.numTicks, 1, `still has 1 tick`);
     });
 
     test('service listeners', function (assert) {

--- a/tests/unit/shared.js
+++ b/tests/unit/shared.js
@@ -30,25 +30,25 @@ export function assertStopwatchListeners(assert, stopwatchOrService, nativeTimer
 
     stopwatchOrService.start();
     nativeTimer.tick(300);
-    assert.equal(listener.tickCount, 3, `should receive 3 events`);
+    assert.strictEqual(listener.tickCount, 3, `should receive 3 events`);
 
     // remove listener
     stopwatchOrService.off('tick', listener.handlers['tick']);
     nativeTimer.tick(1000);
-    assert.equal(listener.tickCount, 3, `should still only have received 3 events`);
+    assert.strictEqual(listener.tickCount, 3, `should still only have received 3 events`);
 
-    assert.equal(listener.startCount, 1, `should still only started once`);
-    assert.equal(listener.stopCount, 0, `should have no stops`);
-    assert.equal(listener.resetCount, 0, `should have no resets`);
+    assert.strictEqual(listener.startCount, 1, `should still only started once`);
+    assert.strictEqual(listener.stopCount, 0, `should have no stops`);
+    assert.strictEqual(listener.resetCount, 0, `should have no resets`);
 
     stopwatchOrService.stop(true);
-    assert.equal(listener.stopCount, 1, `should have 1 stop`);
+    assert.strictEqual(listener.stopCount, 1, `should have 1 stop`);
     stopwatchOrService.start();
-    assert.equal(listener.startCount, 2, `should have 2 starts`);
+    assert.strictEqual(listener.startCount, 2, `should have 2 starts`);
 
     stopwatchOrService.reset(true);
-    assert.equal(listener.resetCount, 1, `should have 1 stop`);
-    assert.equal(listener.stopCount, 2, `should have 2 stops, since reset also stops`);
+    assert.strictEqual(listener.resetCount, 1, `should have 1 stop`);
+    assert.strictEqual(listener.stopCount, 2, `should have 2 stops, since reset also stops`);
 }
 
 export function assertClockListeners(assert, clockOrService, nativeTimer) {
@@ -56,30 +56,30 @@ export function assertClockListeners(assert, clockOrService, nativeTimer) {
     if (clockOrService.start) {
         clockOrService.start();
     }
-    assert.equal(listener.secondCount, 0, `no events yet`);
+    assert.strictEqual(listener.secondCount, 0, `no events yet`);
 
     nativeTimer.tick(SECOND_RESOLUTION);
-    assert.equal(listener.secondCount, 1, `should have received second event`);
-    assert.equal(listener.minuteCount, 0, `should not have received minute event`);
+    assert.strictEqual(listener.secondCount, 1, `should have received second event`);
+    assert.strictEqual(listener.minuteCount, 0, `should not have received minute event`);
 
     // force a minute rollover
     nativeTimer.tick(SECOND_RESOLUTION * 59);
-    assert.equal(listener.secondCount, 60, `should have received 60 second events`);
-    assert.equal(listener.minuteCount, 1, `should have received minute event`);
-    assert.equal(listener.hourCount, 0, `should not have received hour event`);
+    assert.strictEqual(listener.secondCount, 60, `should have received 60 second events`);
+    assert.strictEqual(listener.minuteCount, 1, `should have received minute event`);
+    assert.strictEqual(listener.hourCount, 0, `should not have received hour event`);
 
     // force an hour rollover
     nativeTimer.tick(SECOND_RESOLUTION * 60 * 59);
-    assert.equal(listener.minuteCount, 60, `should have received 60 minute events`);
-    assert.equal(listener.hourCount, 1, `should have received 1 hour event`);
-    assert.equal(listener.dayCount, 0, `should not have received day event`);
+    assert.strictEqual(listener.minuteCount, 60, `should have received 60 minute events`);
+    assert.strictEqual(listener.hourCount, 1, `should have received 1 hour event`);
+    assert.strictEqual(listener.dayCount, 0, `should not have received day event`);
 
     // force a day rollover
     nativeTimer.tick(SECOND_RESOLUTION * 60 * 60 * 23);
-    assert.equal(listener.hourCount, 24, `should have received 24 hour events`);
-    assert.equal(listener.dayCount, 1, `should have received 1 day event`);
+    assert.strictEqual(listener.hourCount, 24, `should have received 24 hour events`);
+    assert.strictEqual(listener.dayCount, 1, `should have received 1 day event`);
 
     clockOrService.off('day', listener.handlers['day']);
     nativeTimer.tick(SECOND_RESOLUTION * 60 * 60 * 24);
-    assert.equal(listener.dayCount, 1, `should have received 1 day event`);
+    assert.strictEqual(listener.dayCount, 1, `should have received 1 day event`);
 }

--- a/tests/unit/utils/clock-test.js
+++ b/tests/unit/utils/clock-test.js
@@ -23,15 +23,15 @@ module('Unit | Utility | clock', function (hooks) {
         assert.expect(2);
         let clock = new Clock();
         assert.ok(clock);
-        assert.equal(clock.tickMillis, SECOND_RESOLUTION);
+        assert.strictEqual(clock.tickMillis, SECOND_RESOLUTION);
     });
 
     test('time is initially set on start', function (assert) {
         assert.expect(2);
         let clock = new Clock();
-        assert.equal(clock.time, undefined, `time is undefined before start`);
+        assert.strictEqual(clock.time, undefined, `time is undefined before start`);
         clock.start();
-        assert.equal(clock.time, SYSTEM_START, `clock should be initially set`);
+        assert.strictEqual(clock.time, SYSTEM_START, `clock should be initially set`);
     });
 
     test('multiple starts are ignored', function (assert) {
@@ -43,7 +43,7 @@ module('Unit | Utility | clock', function (hooks) {
         this.nativeTimer.tick(SECOND_RESOLUTION);
         clock.start();
         this.nativeTimer.tick(SECOND_RESOLUTION);
-        assert.equal(listener.startCount, 1, `clock should ignore multiple starts`);
+        assert.strictEqual(listener.startCount, 1, `clock should ignore multiple starts`);
     });
 
     test('checks event triggers', function (assert) {

--- a/tests/unit/utils/stopwatch-test.js
+++ b/tests/unit/utils/stopwatch-test.js
@@ -19,14 +19,14 @@ module('Unit | Utility | stopwatch', function (hooks) {
         assert.expect(2);
         let stopwatch = new Stopwatch();
         assert.ok(stopwatch);
-        assert.equal(stopwatch.tickMillis, DEFAULT_TICK_MILLIS);
+        assert.strictEqual(stopwatch.tickMillis, DEFAULT_TICK_MILLIS);
     });
 
     test('can create with 0 and use default', function (assert) {
         assert.expect(2);
         let stopwatch = new Stopwatch(0);
         assert.ok(stopwatch);
-        assert.equal(stopwatch.tickMillis, DEFAULT_TICK_MILLIS);
+        assert.strictEqual(stopwatch.tickMillis, DEFAULT_TICK_MILLIS);
     });
 
     test('checks that elapsed time updates', function (assert) {
@@ -36,20 +36,20 @@ module('Unit | Utility | stopwatch', function (hooks) {
         assert.ok(stopwatch.isRunning, `stopwatch should be running`);
 
         this.nativeTimer.tick(99);
-        assert.equal(stopwatch.elapsedMillis, 0, `stopwatch tick has not been triggered yet`);
-        assert.equal(stopwatch.numTicks, 0, `stopwatch tick has not been triggered yet`);
+        assert.strictEqual(stopwatch.elapsedMillis, 0, `stopwatch tick has not been triggered yet`);
+        assert.strictEqual(stopwatch.numTicks, 0, `stopwatch tick has not been triggered yet`);
 
         this.nativeTimer.tick(1);
-        assert.equal(stopwatch.elapsedMillis, 100, `stopwatch tick has been triggered once`);
-        assert.equal(stopwatch.numTicks, 1, `stopwatch tick has been triggered once`);
+        assert.strictEqual(stopwatch.elapsedMillis, 100, `stopwatch tick has been triggered once`);
+        assert.strictEqual(stopwatch.numTicks, 1, `stopwatch tick has been triggered once`);
 
         this.nativeTimer.tick(15);
-        assert.equal(stopwatch.elapsedMillis, 100, `stopwatch tick still should only be triggered once`);
-        assert.equal(stopwatch.numTicks, 1, `stopwatch tick has been triggered once`);
+        assert.strictEqual(stopwatch.elapsedMillis, 100, `stopwatch tick still should only be triggered once`);
+        assert.strictEqual(stopwatch.numTicks, 1, `stopwatch tick has been triggered once`);
 
         this.nativeTimer.tick(85);
-        assert.equal(stopwatch.elapsedMillis, 200, `stopwatch tick should only be triggered twice`);
-        assert.equal(stopwatch.numTicks, 2, `stopwatch tick has been triggered twice`);
+        assert.strictEqual(stopwatch.elapsedMillis, 200, `stopwatch tick should only be triggered twice`);
+        assert.strictEqual(stopwatch.numTicks, 2, `stopwatch tick has been triggered twice`);
     });
 
     test('checks that scheduled stop works', function (assert) {
@@ -68,7 +68,7 @@ module('Unit | Utility | stopwatch', function (hooks) {
         this.nativeTimer.tick(300);
         assert.notOk(stopwatch.isRunning, `stopwatch should not be running`);
 
-        assert.equal(stopwatch.elapsedMillis, 100, `stopwatch should still be at the first tick`);
+        assert.strictEqual(stopwatch.elapsedMillis, 100, `stopwatch should still be at the first tick`);
     });
 
     test('checks that forced stop works', function (assert) {
@@ -80,7 +80,7 @@ module('Unit | Utility | stopwatch', function (hooks) {
 
         this.nativeTimer.tick(300);
         assert.notOk(stopwatch.isRunning, `stopwatch should still not be running`);
-        assert.equal(stopwatch.elapsedMillis, 0, `stopwatch should never have ticked`);
+        assert.strictEqual(stopwatch.elapsedMillis, 0, `stopwatch should never have ticked`);
     });
 
     test('checks that scheduled reset works', function (assert) {
@@ -89,17 +89,17 @@ module('Unit | Utility | stopwatch', function (hooks) {
         stopwatch.start();
 
         this.nativeTimer.tick(299);
-        assert.equal(stopwatch.elapsedMillis, 200, `stopwatch should have ticked twice`);
+        assert.strictEqual(stopwatch.elapsedMillis, 200, `stopwatch should have ticked twice`);
         stopwatch.reset();
         assert.ok(stopwatch.isRunning, `stopwatch should still be running`);
 
         this.nativeTimer.tick(1);
         assert.notOk(stopwatch.isRunning, `stopwatch should not be running`);
-        assert.equal(stopwatch.elapsedMillis, 0, `stopwatch elapsed should be reset`);
+        assert.strictEqual(stopwatch.elapsedMillis, 0, `stopwatch elapsed should be reset`);
 
         this.nativeTimer.tick(500);
         assert.notOk(stopwatch.isRunning, `stopwatch should still not be running`);
-        assert.equal(stopwatch.elapsedMillis, 0, `stopwatch elapsed should still be 0`);
+        assert.strictEqual(stopwatch.elapsedMillis, 0, `stopwatch elapsed should still be 0`);
     });
 
     test('checks that forced reset works', function (assert) {
@@ -108,14 +108,14 @@ module('Unit | Utility | stopwatch', function (hooks) {
         stopwatch.start();
 
         this.nativeTimer.tick(299);
-        assert.equal(stopwatch.elapsedMillis, 200, `stopwatch should have ticked twice`);
+        assert.strictEqual(stopwatch.elapsedMillis, 200, `stopwatch should have ticked twice`);
         stopwatch.reset(true);
         assert.notOk(stopwatch.isRunning, `stopwatch should not be running`);
-        assert.equal(stopwatch.elapsedMillis, 0, `stopwatch elapsed should be reset`);
+        assert.strictEqual(stopwatch.elapsedMillis, 0, `stopwatch elapsed should be reset`);
 
         this.nativeTimer.tick(500);
         assert.notOk(stopwatch.isRunning, `stopwatch should still not be running`);
-        assert.equal(stopwatch.elapsedMillis, 0, `stopwatch elapsed should still be 0`);
+        assert.strictEqual(stopwatch.elapsedMillis, 0, `stopwatch elapsed should still be 0`);
     });
 
     test('checks multiple starts and stops', function (assert) {
@@ -125,14 +125,14 @@ module('Unit | Utility | stopwatch', function (hooks) {
         stopwatch.stop();
         this.nativeTimer.tick(300);
         // first tick
-        assert.equal(stopwatch.elapsedMillis, 100, `stopwatch should have only ticked once`);
+        assert.strictEqual(stopwatch.elapsedMillis, 100, `stopwatch should have only ticked once`);
         assert.notOk(stopwatch.isRunning, `stopwatch should not be running`);
 
         stopwatch.stop();
         assert.notOk(stopwatch.isRunning, `stopwatch should not be running`);
         this.nativeTimer.tick(300);
         assert.notOk(stopwatch.isRunning, `stopwatch should not be running`);
-        assert.equal(stopwatch.elapsedMillis, 100, `stopwatch should have only ticked once`);
+        assert.strictEqual(stopwatch.elapsedMillis, 100, `stopwatch should have only ticked once`);
 
         stopwatch.start();
         stopwatch.start();
@@ -143,7 +143,7 @@ module('Unit | Utility | stopwatch', function (hooks) {
         assert.ok(stopwatch.isRunning, `stopwatch should be running`);
         this.nativeTimer.tick(2000);
         assert.notOk(stopwatch.isRunning, `stopwatch should not be running`);
-        assert.equal(stopwatch.elapsedMillis, 600, `stopwatch should have ticked 6 times`);
+        assert.strictEqual(stopwatch.elapsedMillis, 600, `stopwatch should have ticked 6 times`);
     });
 
     test('checks that event listeners receive events', function (assert) {

--- a/tests/unit/utils/timer-test.js
+++ b/tests/unit/utils/timer-test.js
@@ -18,24 +18,24 @@ module('Unit | Utility | timer', function (hooks) {
         assert.expect(3);
         let timer = new Timer(DEFAULT_RESOLUTION_MILLIS * 10);
         assert.ok(timer);
-        assert.equal(timer.expirationMillis, DEFAULT_RESOLUTION_MILLIS * 10);
-        assert.equal(timer.resolutionMillis, DEFAULT_RESOLUTION_MILLIS);
+        assert.strictEqual(timer.expirationMillis, DEFAULT_RESOLUTION_MILLIS * 10);
+        assert.strictEqual(timer.resolutionMillis, DEFAULT_RESOLUTION_MILLIS);
     });
 
     test('can create with expiration lower than default resolution', function (assert) {
         assert.expect(3);
         let timer = new Timer(DEFAULT_RESOLUTION_MILLIS - 1);
         assert.ok(timer);
-        assert.equal(timer.expirationMillis, DEFAULT_RESOLUTION_MILLIS - 1);
-        assert.equal(timer.resolutionMillis, DEFAULT_RESOLUTION_MILLIS - 1);
+        assert.strictEqual(timer.expirationMillis, DEFAULT_RESOLUTION_MILLIS - 1);
+        assert.strictEqual(timer.resolutionMillis, DEFAULT_RESOLUTION_MILLIS - 1);
     });
 
     test('can attempt to create with higher resolution than expiration', function (assert) {
         assert.expect(3);
         let timer = new Timer(DEFAULT_RESOLUTION_MILLIS, DEFAULT_RESOLUTION_MILLIS * 2);
         assert.ok(timer);
-        assert.equal(timer.expirationMillis, DEFAULT_RESOLUTION_MILLIS);
-        assert.equal(timer.resolutionMillis, DEFAULT_RESOLUTION_MILLIS);
+        assert.strictEqual(timer.expirationMillis, DEFAULT_RESOLUTION_MILLIS);
+        assert.strictEqual(timer.resolutionMillis, DEFAULT_RESOLUTION_MILLIS);
     });
 
     test('checks that remainingMillis updates', function (assert) {
@@ -46,7 +46,7 @@ module('Unit | Utility | timer', function (hooks) {
 
         for (let i = 1; i <= 5; ++i) {
             this.nativeTimer.tick(200);
-            assert.equal(timer.remainingMillis, 1000 - i * 200, `timer expiration is accurate`);
+            assert.strictEqual(timer.remainingMillis, 1000 - i * 200, `timer expiration is accurate`);
             if (i < 5) {
                 // eslint-disable-next-line qunit/no-conditional-assertions
                 assert.ok(timer.isRunning, `timer should be running`);
@@ -57,7 +57,7 @@ module('Unit | Utility | timer', function (hooks) {
         }
 
         this.nativeTimer.tick(200);
-        assert.equal(timer.remainingMillis, 0, `timer remaining should still be 0`);
+        assert.strictEqual(timer.remainingMillis, 0, `timer remaining should still be 0`);
     });
 
     test('checks that multiple starts work', function (assert) {
@@ -66,16 +66,16 @@ module('Unit | Utility | timer', function (hooks) {
         timer.start();
 
         this.nativeTimer.tick(1000);
-        assert.equal(timer.remainingMillis, 0, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 0, `timer expiration is accurate`);
         assert.notOk(timer.isRunning, `timer should not be running`);
         assert.ok(timer.isExpired, `timer should be expired`);
 
         // now start it back up and make sure things are "reset" properly
         timer.start();
-        assert.equal(timer.remainingMillis, 1000, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 1000, `timer expiration is accurate`);
         this.nativeTimer.tick(800);
         assert.ok(timer.isRunning, `timer should not be running`);
-        assert.equal(timer.remainingMillis, 200, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 200, `timer expiration is accurate`);
     });
 
     test('checks that stop works', function (assert) {
@@ -84,21 +84,21 @@ module('Unit | Utility | timer', function (hooks) {
         timer.start();
 
         this.nativeTimer.tick(200);
-        assert.equal(timer.remainingMillis, 800, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 800, `timer expiration is accurate`);
 
         // note that I force a stop so it doesn't do one more tick (since we landed directly on a tick)
         timer.stop(true);
         this.nativeTimer.tick(800);
-        assert.equal(timer.remainingMillis, 800, `timer expiration did not change`);
+        assert.strictEqual(timer.remainingMillis, 800, `timer expiration did not change`);
 
         timer.start();
         this.nativeTimer.tick(200);
-        assert.equal(timer.remainingMillis, 600, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 600, `timer expiration is accurate`);
 
         // if we do not force a stop, the next tick will complete first
         timer.stop();
         this.nativeTimer.tick(800);
-        assert.equal(timer.remainingMillis, 500, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 500, `timer expiration is accurate`);
     });
 
     test('checks that pause works', function (assert) {
@@ -111,15 +111,15 @@ module('Unit | Utility | timer', function (hooks) {
         // force pause
         timer.pause(true);
         this.nativeTimer.tick(800);
-        assert.equal(timer.remainingMillis, 800, `timer expiration did not change`);
+        assert.strictEqual(timer.remainingMillis, 800, `timer expiration did not change`);
 
         timer.start();
         this.nativeTimer.tick(200);
-        assert.equal(timer.remainingMillis, 600, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 600, `timer expiration is accurate`);
 
         timer.pause();
         this.nativeTimer.tick(800);
-        assert.equal(timer.remainingMillis, 500, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 500, `timer expiration is accurate`);
     });
 
     test('checks that restart works', function (assert) {
@@ -128,11 +128,11 @@ module('Unit | Utility | timer', function (hooks) {
         timer.start();
 
         this.nativeTimer.tick(200);
-        assert.equal(timer.remainingMillis, 800, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 800, `timer expiration is accurate`);
         timer.restart();
-        assert.equal(timer.remainingMillis, 1000, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 1000, `timer expiration is accurate`);
         this.nativeTimer.tick(200);
-        assert.equal(timer.remainingMillis, 800, `timer expiration is accurate`);
+        assert.strictEqual(timer.remainingMillis, 800, `timer expiration is accurate`);
     });
 
     test('checks that event listeners receive events', function (assert) {
@@ -150,16 +150,16 @@ module('Unit | Utility | timer', function (hooks) {
 
         timer.start();
         this.nativeTimer.tick(300);
-        assert.equal(expiredCount, 0, `should not have expired yet`);
+        assert.strictEqual(expiredCount, 0, `should not have expired yet`);
 
         this.nativeTimer.tick(700);
-        assert.equal(expiredCount, 1, `should have expired`);
+        assert.strictEqual(expiredCount, 1, `should have expired`);
 
         this.nativeTimer.tick(10000);
-        assert.equal(expiredCount, 1, `should have expired once still`);
+        assert.strictEqual(expiredCount, 1, `should have expired once still`);
 
         timer.restart();
         this.nativeTimer.tick(2000);
-        assert.equal(expiredCount, 2, `second expiration`);
+        assert.strictEqual(expiredCount, 2, `second expiration`);
     });
 });


### PR DESCRIPTION
- eslint-plugin-qunit now reports assert.equal as an error, so updated to use assert.strictEqual
- fixed all warnings in tests as well