### PR TITLE
fix: deprecation warning fixes for ember-modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 1.1.1
+
+This is a patch release that resolves deprecation warnings with ember-modifier.
+
+#### Changes
+
+-   resolve ember-modifier deprecation warnings
+-   use registerDestructor from @ember/destroyable for teardown
+
 ### 1.1.0
 
 This is a minor release composed primarily of dependency updates.

--- a/addon/modifiers/stopwatch-tick.js
+++ b/addon/modifiers/stopwatch-tick.js
@@ -1,41 +1,45 @@
-import Modifier from 'ember-modifier';
 import { assert } from '@ember/debug';
+import { registerDestructor } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
+import Modifier from 'ember-modifier';
 import Stopwatch from '../utils/stopwatch';
 
 const modifierName = 'stopwatch-tick';
 
+const cleanup = (instance) => {
+    const { stopwatch } = instance;
+    if (stopwatch) {
+        try {
+            stopwatch.off('tick', instance, instance._handler);
+        } catch (error) {
+            // ignore, in case the instance was not registered
+        } finally {
+            stopwatch.stop(true);
+        }
+    }
+};
+
 export default class StopwatchTickModifier extends Modifier {
     @tracked stopwatch;
+    @tracked handler;
     @tracked durationMillis;
     @tracked numTicksHandled = 0;
+    @tracked ticks;
 
-    get handler() {
-        return this.args.positional[1];
-    }
-
-    get ticks() {
-        return this.args.named.ticks ?? 1;
-    }
-
-    didReceiveArguments() {
-        assert(`You must provide at least 2 arguments for {{${modifierName}}}`, this.args.positional.length > 1);
-        let durationMillis = this.args.positional[0];
+    modify(element, positionalArgs, { ticks }) {
+        assert(`You must provide at least 2 arguments for {{${modifierName}}}`, positionalArgs.length > 1);
+        let durationMillis = positionalArgs[0];
         assert(
             `You must provide a positive number as the first positional argument for {{${modifierName}}}`,
             typeof durationMillis === 'number' && durationMillis > 0
         );
         this.durationMillis = durationMillis;
+        this.ticks = ticks ?? 1;
+        this.handler = positionalArgs[1];
         this.stopwatch = new Stopwatch(this.durationMillis);
         this.stopwatch.on('tick', this, this._handler);
         this.stopwatch.start(true);
-    }
-
-    willRemove() {
-        if (this.stopwatch) {
-            this.stopwatch.off('tick', this, this._handler);
-            this.stopwatch.stop(true);
-        }
+        registerDestructor(this, cleanup);
     }
 
     _handler() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-stopwatch",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-stopwatch",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "ember-cli-babel": "^7.26.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-stopwatch",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Stopwatches, timers, clocks, oh my!",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
-   resolve ember-modifier deprecation warnings
-   use registerDestructor from @ember/destroyable for teardown